### PR TITLE
Implementing port selection via host:port

### DIFF
--- a/polysh/dispatchers.py
+++ b/polysh/dispatchers.py
@@ -26,6 +26,15 @@ from polysh import remote_dispatcher
 from polysh import display_names
 from polysh.terminal_size import terminal_size
 
+def _split_port(hostname):
+    """ Splits a string(hostname, given by the user) into hostname and port, 
+    returns a tuple """
+    s = hostname.split(':', 1)
+    if len(s) > 1:
+        return s[0], s[1]
+    else:
+        return s[0], '22'
+
 
 def all_instances():
     """Iterator over all the remote_dispatcher instances"""
@@ -108,7 +117,8 @@ def create_remote_dispatchers(hosts):
             sys.stdout.write(last_message)
             sys.stdout.flush()
         try:
-            remote_dispatcher.RemoteDispatcher(host)
+            hostname, port = _split_port(host)
+            remote_dispatcher.RemoteDispatcher(hostname, port)
         except OSError:
             print()
             raise

--- a/polysh/host_syntax.py
+++ b/polysh/host_syntax.py
@@ -29,8 +29,8 @@ import re
 syntax_pattern = re.compile('<([0-9,-]+)>')
 interval_pattern = re.compile('([0-9]+)(-[0-9]+)?')
 
-def _get_port(hostname):
-    s = hostname.split(':')
+def _split_port(hostname):
+    s = hostname.split(':',1)
     if len(s) > 1:
         return s[0], s[1]
     else:
@@ -70,4 +70,4 @@ def expand_syntax(string):
                     for expanded in expand_syntax(prefix + i + suffix):
                         yield expanded
     else:
-        yield _get_port(string)
+        yield _split_port(string)

--- a/polysh/host_syntax.py
+++ b/polysh/host_syntax.py
@@ -29,6 +29,12 @@ import re
 syntax_pattern = re.compile('<([0-9,-]+)>')
 interval_pattern = re.compile('([0-9]+)(-[0-9]+)?')
 
+def _get_port(hostname):
+    s = hostname.split(':')
+    if len(s) > 1:
+        return s[0], s[1]
+    else:
+        return s[0], '22'
 
 def _iter_numbers(start, end):
     int_start = int(start)
@@ -64,4 +70,4 @@ def expand_syntax(string):
                     for expanded in expand_syntax(prefix + i + suffix):
                         yield expanded
     else:
-        yield string
+        yield _get_port(string)

--- a/polysh/host_syntax.py
+++ b/polysh/host_syntax.py
@@ -30,7 +30,7 @@ syntax_pattern = re.compile('<([0-9,-]+)>')
 interval_pattern = re.compile('([0-9]+)(-[0-9]+)?')
 
 def _split_port(hostname):
-    s = hostname.split(':',1)
+    s = hostname.split(':', 1)
     if len(s) > 1:
         return s[0], s[1]
     else:
@@ -70,4 +70,4 @@ def expand_syntax(string):
                     for expanded in expand_syntax(prefix + i + suffix):
                         yield expanded
     else:
-        yield _split_port(string)
+        yield string

--- a/polysh/main.py
+++ b/polysh/main.py
@@ -58,7 +58,7 @@ def parse_cmdline():
         '--command', type=str, dest='command', default=None,
         help='command to execute on the remote shells',
         metavar='CMD')
-    def_ssh = 'exec ssh -oLogLevel=Quiet -t %(host)s -p %(port)s exec bash --noprofile'
+    def_ssh = 'exec ssh -oLogLevel=Quiet -t %(host)s %(port)s exec bash --noprofile'
     parser.add_argument(
         '--ssh', type=str, dest='ssh', default=def_ssh,
         metavar='SSH', help='ssh command to use [%s]' % def_ssh)

--- a/polysh/main.py
+++ b/polysh/main.py
@@ -58,7 +58,7 @@ def parse_cmdline():
         '--command', type=str, dest='command', default=None,
         help='command to execute on the remote shells',
         metavar='CMD')
-    def_ssh = 'exec ssh -oLogLevel=Quiet -t %(host)s exec bash --noprofile'
+    def_ssh = 'exec ssh -oLogLevel=Quiet -t %(host)s -p %(port)s exec bash --noprofile'
     parser.add_argument(
         '--ssh', type=str, dest='ssh', default=def_ssh,
         metavar='SSH', help='ssh command to use [%s]' % def_ssh)

--- a/polysh/remote_dispatcher.py
+++ b/polysh/remote_dispatcher.py
@@ -117,7 +117,6 @@ class RemoteDispatcher(BufferedDispatcher):
         evaluated = options.ssh % {'host': name, 'port': port}
         if evaluated == options.ssh:
             evaluated = '%s %s' % (evaluated, name)
-        print(evaluated)
         os.execlp('/bin/sh', 'sh', '-c', evaluated)
 
     def set_enabled(self, enabled):

--- a/polysh/remote_dispatcher.py
+++ b/polysh/remote_dispatcher.py
@@ -73,11 +73,14 @@ def log(msg):
 class RemoteDispatcher(BufferedDispatcher):
     """A RemoteDispatcher is a ssh process we communicate with"""
 
-    def __init__(self, host):
-        assert isinstance(host, tuple)
-        hostname, port = host
+    def __init__(self, hostname, port):
         assert isinstance(hostname, str)
         assert isinstance(port, str)
+
+        if port != "22":
+            port = "-p " + port
+        else:
+            port = ''
 
         self.pid, fd = pty.fork()
         if self.pid == 0:
@@ -114,6 +117,7 @@ class RemoteDispatcher(BufferedDispatcher):
         evaluated = options.ssh % {'host': name, 'port': port}
         if evaluated == options.ssh:
             evaluated = '%s %s' % (evaluated, name)
+        print(evaluated)
         os.execlp('/bin/sh', 'sh', '-c', evaluated)
 
     def set_enabled(self, enabled):

--- a/polysh/remote_dispatcher.py
+++ b/polysh/remote_dispatcher.py
@@ -73,18 +73,23 @@ def log(msg):
 class RemoteDispatcher(BufferedDispatcher):
     """A RemoteDispatcher is a ssh process we communicate with"""
 
-    def __init__(self, hostname):
+    def __init__(self, host):
+        assert isinstance(host, tuple)
+        hostname, port = host
         assert isinstance(hostname, str)
+        assert isinstance(port, str)
+
         self.pid, fd = pty.fork()
         if self.pid == 0:
             # Child
-            self.launch_ssh(hostname)
+            self.launch_ssh(hostname, port)
             sys.exit(1)
 
         # Parent
         super().__init__(fd)
         self.temporary = False
         self.hostname = hostname
+        self.port = port
         self.debug = options.debug
         self.enabled = True  # shells can be enabled and disabled
         self.state = STATE_NOT_STARTED
@@ -102,11 +107,11 @@ class RemoteDispatcher(BufferedDispatcher):
         else:
             self.color_code = None
 
-    def launch_ssh(self, name):
+    def launch_ssh(self, name, port):
         """Launch the ssh command in the child process"""
         if options.user:
             name = '%s@%s' % (options.user, name)
-        evaluated = options.ssh % {'host': name}
+        evaluated = options.ssh % {'host': name, 'port': port}
         if evaluated == options.ssh:
             evaluated = '%s %s' % (evaluated, name)
         os.execlp('/bin/sh', 'sh', '-c', evaluated)


### PR DESCRIPTION
Hey there,
this PR makes it possible to specify the target port for the ssh connection in the hostname:port syntax where :port is optional.
Example usage:
`polysh 10.0.0.1:42, 10.0.1.<7-13>:20`

I'm not quite sure if this PR is really needed since its possible to specify the port in your ssh config but I found it useful in some cases.

Please test before merging, especially with host-expansion. 
Feel free to criticise my coding style 🤔