### PR TITLE
Stop overwriting the users login shell

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -66,15 +66,15 @@ Options
 `--ssh=SSH`
     Command to use for SSH
 
-    By default, `exec ssh -oLogLevel=Quiet -t %(host)s exec bash --noprofile`.
-    `polysh` spawns lightweight remote shells using
-    the ssh command, but another shell command can be specified here.
-    For example, with `--ssh='usleep $((RANDOM*50)); exec ssh'` a delay
-    will be introduced to avoid all hosts accessing a NFS server at
-    the same time.  If the hostname should not be added at the end of
-    the command, the macro `%(host)s` can be inserted where the hostname
-    should be placed.  Also, make sure the command you use launches a `pty`,
-    this may need the `-t` option for `ssh`.
+    By default, `exec ssh -oLogLevel=Quiet -t %(host)s %(port)s`.
+    `polysh` spawns ssh for each connection which may spawn your default login
+    shell on the remote, but another shell command can be specified here. For
+    example, with `--ssh='usleep $((RANDOM*50)); exec ssh'` a delay will be
+    introduced to avoid all hosts accessing a NFS server at the same time.  If
+    the hostname should not be added at the end of the command, the macro
+    `%(host)s` can be inserted where the hostname should be placed.  Also, make
+    sure the command you use launches a `pty`, this may need the `-t` option for
+    `ssh`.
 
 `--user=USER`
     Remote user to log in as

--- a/polysh/main.py
+++ b/polysh/main.py
@@ -58,7 +58,7 @@ def parse_cmdline():
         '--command', type=str, dest='command', default=None,
         help='command to execute on the remote shells',
         metavar='CMD')
-    def_ssh = 'exec ssh -oLogLevel=Quiet -t %(host)s %(port)s exec bash --noprofile'
+    def_ssh = 'exec ssh -oLogLevel=Quiet -t %(host)s %(port)s'
     parser.add_argument(
         '--ssh', type=str, dest='ssh', default=def_ssh,
         metavar='SSH', help='ssh command to use [%s]' % def_ssh)

--- a/tests/tests/basic.py
+++ b/tests/tests/basic.py
@@ -19,6 +19,7 @@ Copyright (c) 2018 InnoGames GmbH
 import unittest
 import pexpect
 from polysh_tests import launch_polysh
+from time import sleep
 
 
 class TestBasic(unittest.TestCase):
@@ -59,6 +60,7 @@ class TestBasic(unittest.TestCase):
         child.expect('ready \(1\)> ')
         child.sendline('sleep 1')
         child.expect('waiting \(1/1\)> ')
+        sleep(1)
         child.send('echo begin-')
         child.expect('ready \(1\)> ')
         child.sendline('end')

--- a/tests/tests/basic.py
+++ b/tests/tests/basic.py
@@ -39,7 +39,7 @@ class TestBasic(unittest.TestCase):
             child = start_child()
             child.sendline('exit')
             for i in range(nr_localhost):
-                child.expect('exit')
+                child.expect('logout')
             child.expect(pexpect.EOF)
 
         test_eof()
@@ -79,7 +79,9 @@ class TestBasic(unittest.TestCase):
         child = launch_polysh(['localhost', 'localhost'])
         child.expect('ready \(2\)> ')
         child.sendeof()
-        idx = child.expect(['Error talking to localhost', 'exit'])
+        # We test for logout as this is the expected response of sending EOF to
+        # a non login shell
+        idx = child.expect(['Error talking to localhost', 'logout'])
         self.assertEqual(idx, 1)
         idx = child.expect(['Error talking to localhost', pexpect.EOF])
         self.assertEqual(idx, 1)


### PR DESCRIPTION
Before we loaded bash with no profile to make it quick, hide MOTDs etc.
We actually do want aliases and co to work though so we want to get rid
of this behavior.  Further we no longer spawn shells in --command more
anymore which is also a good thing.

Note polysh has special hacks for bash to recognize the prompt and
overwrite the PS1 which may not work for other shells at the moment.