### PR TITLE
feature: Dis/Enable shell based on last output

### DIFF
--- a/polysh/control_commands_helpers.py
+++ b/polysh/control_commands_helpers.py
@@ -59,7 +59,10 @@ def selected_shells(
         for expanded_pattern in expand_syntax(pattern):
             for i in dispatchers.all_instances():
                 instance_found = True
-                if fnmatch(i.display_name, expanded_pattern):
+                if (
+                    fnmatch(i.display_name, expanded_pattern) or
+                    fnmatch(str(i.last_printed_line), expanded_pattern)
+                ):
                     found = True
                     if i not in selected:
                         selected.add(i)


### PR DESCRIPTION
It can be useful to disable certain shells based on the output of the
last line. For example the disable all shells which had *error* in the
output of the last line.

fixes #12 