### PR TITLE
Fix argparse usage

### DIFF
--- a/polysh/main.py
+++ b/polysh/main.py
@@ -49,9 +49,8 @@ def kill_all() -> None:
 
 
 def parse_cmdline() -> argparse.Namespace:
-    usage = '%s [OPTIONS] HOSTS...\n' % (sys.argv[0]) + \
-            'Control commands are prefixed by ":".'
-    parser = argparse.ArgumentParser(usage)
+    description = 'Control commands are prefixed by ":".'
+    parser = argparse.ArgumentParser(description=description)
     parser.add_argument(
         '--hosts-file', type=str, action='append',
         dest='hosts_filenames', metavar='FILE', default=[],
@@ -63,7 +62,7 @@ def parse_cmdline() -> argparse.Namespace:
     def_ssh = 'exec ssh -oLogLevel=Quiet -t %(host)s %(port)s'
     parser.add_argument(
         '--ssh', type=str, dest='ssh', default=def_ssh,
-        metavar='SSH', help='ssh command to use [%s]' % def_ssh)
+        metavar='SSH', help='ssh command to use [%(default)s]')
     parser.add_argument(
         '--user', type=str, dest='user', default=None,
         help='remote user to log in as', metavar='USER')


### PR DESCRIPTION
Make -h/--help work by fixing "help" argument of --ssh action.

Use argparse default usage string.

With Python 3.9.9

Before:
![image](https://user-images.githubusercontent.com/4948057/150735149-d176cd6b-3fb8-4952-95e5-90aa028681a6.png)

After:
![image](https://user-images.githubusercontent.com/4948057/150735212-a0595f8f-d04a-4d45-9112-2c7baaf920f2.png)
