### PR TITLE
Set enable-bracketed-paste off on remote hosts

### DIFF
--- a/polysh/remote_dispatcher.py
+++ b/polysh/remote_dispatcher.py
@@ -160,7 +160,7 @@ class RemoteDispatcher(BufferedDispatcher):
         attr[3] &= ~termios.ECHO  # type: ignore # lflag
         termios.tcsetattr(self.fd, termios.TCSANOW, attr)
         # unsetopt zle prevents Zsh from resetting the tty
-        return b'unsetopt zle 2> /dev/null;stty -echo -onlcr -ctlecho;'
+        return b'unsetopt zle 2> /dev/null;stty -echo -onlcr -ctlecho; bind "set enable-bracketed-paste off" 2> /dev/null;'
 
     def seen_prompt_cb(self, unused: str) -> None:
         if options.interactive:


### PR DESCRIPTION
Without it, on hosts running bash 5.x/readline 8.x, bracketed-paste mode characters are sent before the prompt "polysh-xxxx:prompt:0/" causing polysh to display the remote host prompts twice (i.e. like there's a blank newline to display).

Try polysh with a stock Ubuntu 22.04 for example.